### PR TITLE
add score to hard-coded Mus

### DIFF
--- a/R/opentree_taxonomy_general.R
+++ b/R/opentree_taxonomy_general.R
@@ -50,7 +50,7 @@ tnrs_match.default <- function(input, reference_taxonomy = "ott", ...) { # enhan
     # cat("\n") # just to make the progress bar look better
     # hardcoding Mus:
     if (sum("mus" == tolower(input)) > 0) {
-      df["mus" == tolower(input), ] <- list("mus", "Mus (genus in Deuterostomia)", FALSE, 1068778, FALSE, "SIBLING_HIGHER", 3)
+      df["mus" == tolower(input), ] <- list("mus", "Mus (genus in Deuterostomia)", FALSE, 1, 1068778, FALSE, "SIBLING_HIGHER", 3)
     }
     rownames(df)[1] <- "1"
     # df[is.na(df$unique_name),1] <- input[is.na(df$unique_name)]  # in case the unmatched input are dropped from final df

--- a/R/opentree_taxonomy_general.R
+++ b/R/opentree_taxonomy_general.R
@@ -50,7 +50,11 @@ tnrs_match.default <- function(input, reference_taxonomy = "ott", ...) { # enhan
     # cat("\n") # just to make the progress bar look better
     # hardcoding Mus:
     if (sum("mus" == tolower(input)) > 0) {
-      df["mus" == tolower(input), ] <- list("mus", "Mus (genus in Deuterostomia)", FALSE, 1, 1068778, FALSE, "SIBLING_HIGHER", 3)
+      if (packageVersion("rotl") >= 3.1.0) {
+        df["mus" == tolower(input), ] <- list("mus", "Mus (genus in Deuterostomia)", FALSE, 1, 1068778, FALSE, "SIBLING_HIGHER", 3)
+      } else {
+        df["mus" == tolower(input), ] <- list("mus", "Mus (genus in Deuterostomia)", FALSE, 1068778, FALSE, "SIBLING_HIGHER", 3)
+      }
     }
     rownames(df)[1] <- "1"
     # df[is.na(df$unique_name),1] <- input[is.na(df$unique_name)]  # in case the unmatched input are dropped from final df


### PR DESCRIPTION
Hello,

I'm preparing a new release for rotl which includes a "breaking change". The output of the the `tnrs_match_names` now includes a new column called `score`. When there are multiple matches in OTL for a taxon, `tnrs_match_names` always returns the taxa with the highest score.

Given that the datelife code hardcodes the format of the tnrs_match_names output, I included this score for the Mus. 

With this fix, the vignettes now build but I haven't tested if there are other side effects.

Thanks!